### PR TITLE
Dont use travis python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,13 +41,14 @@ before_install:
     plplot12-driver-xwin
     pslib-dev
     libeigen3-dev
+  - export PATH=/usr/bin:/bin
 
 before_script:
   - mkdir build
   - cd build
   - >-
     cmake ..
-    -DPYTHON=YES -DPYTHONVERSION=2.7 -DPYTHONDIR=/usr
+    -DPYTHON=YES
     -DFFTW=YES -DWXWIDGETS=YES -DGRIB=YES -DUDUNITS=YES -DPSLIB=YES
 
 script:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -711,7 +711,7 @@ if(PYTHON OR PYTHON_MODULE)
 		find_library(PYTHONLIBS 
                   NAMES python${PYTHONVERSION}
                   PATHS ${PYTHONDIR} 
-                  PATH_SUFFIXES lib lib/python${PYTHONVERSION}/config
+                  PATH_SUFFIXES lib lib/python${PYTHONVERSION}/config 
                   NO_DEFAULT_PATH NO_CMAKE_PATH
                 )
                 string(COMPARE NOTEQUAL "${PYTHONLIBS}" "PYTHONLIBS-NOTFOUND" PYTHONLIBS_FOUND) 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -711,7 +711,7 @@ if(PYTHON OR PYTHON_MODULE)
 		find_library(PYTHONLIBS 
                   NAMES python${PYTHONVERSION}
                   PATHS ${PYTHONDIR} 
-                  PATH_SUFFIXES lib lib/python${PYTHONVERSION}/config lib/python${PYTHONVERSION}/config-x86_64-linux-gnu/
+                  PATH_SUFFIXES lib lib/python${PYTHONVERSION}/config
                   NO_DEFAULT_PATH NO_CMAKE_PATH
                 )
                 string(COMPARE NOTEQUAL "${PYTHONLIBS}" "PYTHONLIBS-NOTFOUND" PYTHONLIBS_FOUND) 


### PR DESCRIPTION
Limit the path to /usr/bin:bin to to exclude addtional Python binaries in /opt